### PR TITLE
Fix NullPointerException of click info

### DIFF
--- a/src/main/java/org/shininet/bukkit/playerheads/PlayerHeadsListener.java
+++ b/src/main/java/org/shininet/bukkit/playerheads/PlayerHeadsListener.java
@@ -195,8 +195,8 @@ public class PlayerHeadsListener implements Listener {
             if (player.hasPermission("playerheads.clickinfo")) {
                 switch (skullState.getSkullType()) {
                     case PLAYER:
-                        if (skullState.hasOwner()) {
-                            String owner = skullState.getOwner();
+                        String owner = skullState.getOwner();
+                        if (skullState.hasOwner() && owner != null) {
                             //String ownerStrip = ChatColor.stripColor(owner); //Unnecessary?
                             CustomSkullType skullType = CustomSkullType.get(owner);
                             if (skullType != null) {


### PR DESCRIPTION
Some special heads have owner, but the owner has only `id` but not `name`.
Take decoration heads for example, like the following website.
http://www.minecraft-heads.com/

The given command is like

```
/give @p skull 1 3 {display:{Name:"Scrambled Rubik's Cube"},SkullOwner:{Id:"ca88bec6-5efc-4917-bdbc-7ead2834b614",Properties:{textures:[{Value:"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzk0ZTI1NGYyMjdlYzk0YWRkZjM5NGVmNWMxNWNkNTBmYjJlYjUyZmUyMWYwOTA5ODI5NjZjY2QwODcxMCJ9fX0="}]}}}
```

There is no `name` in `SkullOwner`.

When we click on this kind of head, NullPointerException throws.
This RP fixed it.
